### PR TITLE
Save call to `strlen` when parsing lines

### DIFF
--- a/speck.c
+++ b/speck.c
@@ -109,11 +109,10 @@ int alloc_sprintf(char **str, const char *format, ...)
     return size;
 }
 
-char *str_match(const char text[])
+char *str_match(const char text[], size_t textlen)
 {
     char str[] = "void spec_";
     int len = 10;
-    size_t textlen = strlen(text);
 
     if (textlen >= len) {
         for (int i = 0; i < len; i++) {
@@ -146,7 +145,7 @@ void get_tests(struct suite *suite)
     ssize_t len;
     int test_count = 0;
     while ((len = getline(&line, &linelen, fp)) > 0) {
-        char *temp = str_match(line);
+        char *temp = str_match(line, len);
         if (temp) {
             suite->tests = realloc(suite->tests, (test_count + 1) * sizeof(char *));
             suite->tests[test_count++] = temp;


### PR DESCRIPTION
This is a sweet project! While reading through the code (which is very clean and easy to understand, btw.) I noticed this call to `strlen`.

The line length is already determined by `getline`, which means we can save a call to `strlen` if we just pass it to `str_match`. And that's exactly what this commit does: save one call of `strlen` per line.

Of course the functionality stays the same and this is not a bug, but rather a small optimization. Just something that caught my eye.

What do you think?