### PR TITLE
Closes #9 - Show line numbers of failed assertions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN=speck
 all: $(BIN)
 
 SPECK_PATH=.
-include speck.mk
+-include speck.mk
 
 test: $(SPECK) $(SUITES)
 	@$(SPECK)

--- a/spec/example.c
+++ b/spec/example.c
@@ -1,5 +1,4 @@
-#include <stdio.h>
-#include "../speck.h"
+#include <speck.h>
 
 void spec_sample_one(void)
 {

--- a/spec/example2.c
+++ b/spec/example2.c
@@ -1,5 +1,4 @@
-#include <stdio.h>
-#include "../speck.h"
+#include <speck.h>
 
 void spec_sample_one(void)
 {

--- a/speck.c
+++ b/speck.c
@@ -297,7 +297,7 @@ struct statistic *build_statistic(struct suite **suites)
                     alloc_sprintf(&(statistic->failures[index]), "");
                 } else {
                     sprintf(statistic->symbols + length, "%sF", colors.red);
-                    alloc_sprintf(&(statistic->failures[index]), "  - %s::%s", suites[suite]->name, suites[suite]->states[state]->assertions[assertion]);
+                    alloc_sprintf(&(statistic->failures[index]), "  - %s.c%s", suites[suite]->name, suites[suite]->states[state]->assertions[assertion]);
                     statistic->flag = 1;
                 }
 

--- a/speck.h
+++ b/speck.h
@@ -63,10 +63,12 @@ int alloc_sprintf(char **str, const char *format, ...)
 
 /* Assertions */
 
-void sp_assert(int expr)
+#define sp_assert(expr) sp_assert_lineno(expr, __LINE__)
+
+void sp_assert_lineno(int expr, int lineno)
 {
     state.assertions = realloc(state.assertions, (state.index + 1) * sizeof(char *));
-    alloc_sprintf(&(state.assertions[state.index]), "%s::sp_assert(%d)", state.function, expr);
+    alloc_sprintf(&(state.assertions[state.index]), ":%d -> %s::sp_assert(%d)", lineno, state.function, expr);
 
     state.codes = realloc(state.codes, (state.index + 1) * sizeof(int));
 
@@ -79,10 +81,12 @@ void sp_assert(int expr)
     state.index++;
 }
 
-void sp_assert_equal_i(int x, int y)
+#define sp_assert_equal_i(x, y) sp_assert_equal_i_lineno(x, y, __LINE__)
+
+void sp_assert_equal_i_lineno(int x, int y, int lineno)
 {
     state.assertions = realloc(state.assertions, (state.index + 1) * sizeof(char *));
-    alloc_sprintf(&(state.assertions[state.index]), "%s::sp_assert(%d, %d)", state.function, x, y);
+    alloc_sprintf(&(state.assertions[state.index]), ":%d -> %s::sp_assert(%d, %d)", lineno, state.function, x, y);
 
     state.codes = realloc(state.codes, (state.index + 1) * sizeof(int));
 


### PR DESCRIPTION
FFFFF

Failures:
  - example.c:6 -> spec_sample_one::sp_assert(42, 41)
  - example.c:7 -> spec_sample_one::sp_assert(0)
  - example2.c:6 -> spec_sample_one::sp_assert(0)
  - example2.c:7 -> spec_sample_one::sp_assert(23, 2)
  - example2.c:12 -> spec_sample_two::sp_assert(0)