### PR TITLE
Added gcc to _travis.yml and use c11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 sudo: false
 compiler:
   - clang
+  - gcc
 addons:
   apt:
     packages:

--- a/speck.mk
+++ b/speck.mk
@@ -4,7 +4,7 @@ SUITES=$(patsubst %.c, %.so, $(wildcard spec/*.c))
 SPECK_VERSION=$(shell git describe --tags --dirty=+ || echo "UNKNOWN")
 
 $(SPECK): $(SPECK).c
-	@$(CC) -std=c11 -Wall -g -o $@ -DSPECK_VERSION=\"$(SPECK_VERSION)\" $< -ldl
+	@$(CC) -std=c1x -Wall -g -o $@ -DSPECK_VERSION=\"$(SPECK_VERSION)\" $< -ldl
 
 spec/%.so: spec/%.c
 	@$(CC) -Wall -g -I$(SPECK_PATH) $(SPECK_CFLAGS) $(SPECK_LDFLAGS) -fPIC -shared -o $@ $< $(SPECK_LIBS)


### PR DESCRIPTION
We have to use '-std=c1x' because of the super old gcc version of Travis CI.