### PR TITLE
Support Other Brace Styles

### DIFF
--- a/spec/example2.c
+++ b/spec/example2.c
@@ -10,3 +10,7 @@ void spec_sample_two(void)
 {
     sp_assert(23);
 }
+
+void spec_sample_three(void) {
+    sp_assert(42);
+}

--- a/speck.c
+++ b/speck.c
@@ -162,14 +162,17 @@ char *str_match(const char text[], size_t textlen)
         }
 
         int pre_offset = 5; /* "void " */
-        int post_offset = 7; /* "(void)\n" */
 
-        char *match = malloc((textlen - pre_offset - post_offset + 1) * sizeof(char));
+        char *match_end = strstr(text, "(void)");
+        if (match_end) {
+          size_t match_len = match_end - text - pre_offset;
+          char *match = malloc((match_len + 1) * sizeof(char));
 
-        memcpy(match, text + pre_offset, textlen - pre_offset - post_offset);
-        match[textlen - pre_offset - post_offset] = '\0';
+          memcpy(match, text + pre_offset, match_len);
+          match[match_len] = '\0';
 
-        return match;
+          return match;
+        }
     }
 
     return NULL;


### PR DESCRIPTION
The primary motivation here was that I happen to use same-line braces for function declarations (arguably not a good habit for C, but not one I'm likely to break anytime soon). The previous implementation of `str_match` resulted in a segfault with that format because it extracted an incorrect function name from the line.

The changes here:
1. Change the implementation of `str_match` to be a bit more flexible with the formatting of the function declaration line.
2. Catch cases like this when running specs to avoid a segfault & fail the test with an explanatory message: even with the fix to `str_match`, there are other cases that could result in invalid function names getting matched, so this seems worthwhile.
