### PR TITLE
Makefile: make spec.so depend on SPECK_LIBS

### DIFF
--- a/speck.mk
+++ b/speck.mk
@@ -6,5 +6,5 @@ SPECK_VERSION=$(shell git describe --tags --dirty=+ || echo "UNKNOWN")
 $(SPECK): $(SPECK).c
 	@$(CC) -std=c1x -Wall -g -o $@ -DSPECK_VERSION=\"$(SPECK_VERSION)\" $< -ldl
 
-spec/%.so: spec/%.c
+spec/%.so: spec/%.c $(SPECK_LIBS)
 	@$(CC) -Wall -g -I$(SPECK_PATH) $(SPECK_CFLAGS) $(SPECK_LDFLAGS) -fPIC -shared -o $@ $< $(SPECK_LIBS)


### PR DESCRIPTION
This forces recompilation of a speck when the related implementations
change as well. Unfortunately, since all libs are linked to all specks,
it means pretty much any impl change will rebuild all specs. The
alternative is manually running `clean` in addition to `test`, which
generally would *also* mean rebuilding all the SPECK_LIBS themselves, so
this seems like an acceptable cost.

