### PR TITLE
Use version from speck when it's cloned as submodule

### DIFF
--- a/speck.mk
+++ b/speck.mk
@@ -1,7 +1,7 @@
 SPECK_PATH? = speck
 SPECK = $(SPECK_PATH)/speck
 SUITES = $(patsubst %.c, %.so, $(wildcard spec/*.c))
-SPECK_VERSION = $(shell git describe --tags --dirty=+ || echo "UNKNOWN")
+SPECK_VERSION = $(shell cd $(SPECK_PATH); git describe --tags --dirty=+ || echo "UNKNOWN")
 
 $(SPECK): $(SPECK).c
 	@$(CC) -std=c1x -Wall -g -o $@ -DSPECK_VERSION=\"$(SPECK_VERSION)\" $< -ldl


### PR DESCRIPTION
Speck gets version info via shell invocation of `git describe`. It must
be invoked from a "speck" dir (--git-dir doesn't work for submodules).

This commit adds `cd` into "speck" dir to make `git describe` work. Note that
we don't need to `cd` back because `make` spawns a new separate shell for
that.

This fixes issue #22 